### PR TITLE
Bugfix for choices of dup_ok

### DIFF
--- a/iam_cert.py
+++ b/iam_cert.py
@@ -228,7 +228,7 @@ def main():
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
         new_path=dict(default=None, required=False),
-        dup_ok=dict(default=False, required=False, choices=[False, True])
+        dup_ok=dict(default=False, required=False, choices=['False', 'True'])
     )
     )
 


### PR DESCRIPTION
The choices for dup_ok on line 231 need to be quoted. Without the quotes, it throws:

>"msg": "value of dup_ok must be one of: False,True, got: False"}

After this pull, iam_cert works as expected.